### PR TITLE
Fix GLFW linking

### DIFF
--- a/test/testCube/CMakeLists.txt
+++ b/test/testCube/CMakeLists.txt
@@ -45,4 +45,4 @@ endforeach()
 add_executable(${PROJECT_NAME} ${SOURCES} ${HEADERS})
 
 # Linker
-target_link_libraries(${PROJECT_NAME} glfw RendererGL)
+target_link_libraries(${PROJECT_NAME} glfw3 RendererGL)

--- a/test/testHDRI/CMakeLists.txt
+++ b/test/testHDRI/CMakeLists.txt
@@ -45,4 +45,4 @@ endforeach()
 add_executable(${PROJECT_NAME} ${SOURCES} ${HEADERS} ${IMGUI_SOURCES} ${IMGUI_HEADERS})
 
 # Linker
-target_link_libraries(${PROJECT_NAME} glfw RendererGL)
+target_link_libraries(${PROJECT_NAME} glfw3 RendererGL)

--- a/test/testImGuiGLFW/CMakeLists.txt
+++ b/test/testImGuiGLFW/CMakeLists.txt
@@ -45,4 +45,4 @@ endforeach()
 add_executable(${PROJECT_NAME} ${SOURCES} ${HEADERS} ${IMGUI_SOURCES} ${IMGUI_HEADERS})
 
 # Linker
-target_link_libraries(${PROJECT_NAME} glfw RendererGL)
+target_link_libraries(${PROJECT_NAME} glfw3 RendererGL)

--- a/test/testLighting/CMakeLists.txt
+++ b/test/testLighting/CMakeLists.txt
@@ -45,4 +45,4 @@ endforeach()
 add_executable(${PROJECT_NAME} ${SOURCES} ${HEADERS})
 
 # Linker
-target_link_libraries(${PROJECT_NAME} glfw RendererGL)
+target_link_libraries(${PROJECT_NAME} glfw3 RendererGL)

--- a/test/testModelPBR/CMakeLists.txt
+++ b/test/testModelPBR/CMakeLists.txt
@@ -45,4 +45,4 @@ endforeach()
 add_executable(${PROJECT_NAME} ${SOURCES} ${HEADERS} ${IMGUI_SOURCES} ${IMGUI_HEADERS})
 
 # Linker
-target_link_libraries(${PROJECT_NAME} glfw RendererGL)
+target_link_libraries(${PROJECT_NAME} glfw3 RendererGL)

--- a/test/testPBR/CMakeLists.txt
+++ b/test/testPBR/CMakeLists.txt
@@ -45,4 +45,4 @@ endforeach()
 add_executable(${PROJECT_NAME} ${SOURCES} ${HEADERS})
 
 # Linker
-target_link_libraries(${PROJECT_NAME} glfw RendererGL)
+target_link_libraries(${PROJECT_NAME} glfw3 RendererGL)

--- a/test/testPointCloud/CMakeLists.txt
+++ b/test/testPointCloud/CMakeLists.txt
@@ -45,4 +45,4 @@ endforeach()
 add_executable(${PROJECT_NAME} ${SOURCES} ${HEADERS} ${IMGUI_SOURCES} ${IMGUI_HEADERS})
 
 # Linker
-target_link_libraries(${PROJECT_NAME} glfw RendererGL)
+target_link_libraries(${PROJECT_NAME} glfw3 RendererGL)


### PR DESCRIPTION
The compilation requires installed glfw binaries which use the name `glfw3`. See:
https://www.glfw.org/docs/latest/build_guide.html#build_link_cmake_package

Currently it will fail with
```
cannot find -lglfw: No such file or directory
```

With this patch it will successfully build under MinGW64.